### PR TITLE
Add advanced search with page context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+These instructions apply to the entire repository.
+
+# Testing
+
+- Run `./build/run_backend_testcases.sh` to execute tests. Do **not** run `pytest` directly.
+

--- a/src/backend/chat_service/chat_service.py
+++ b/src/backend/chat_service/chat_service.py
@@ -46,6 +46,11 @@ class GetAllChatsRequest(BaseModel):
 class DeleteChatsRequest(BaseModel):
     chat_id: str
 
+class AdvancedSearchRequest(BaseModel):
+    question: str
+    top_k: int = 3
+    alpha: float = 0.5
+
 # API endpoint to add a new customer
 @app.post("/addcustomer", tags=["Customer Management"])
 async def add_customer(request: Request, auth=Depends(auth_admin_dependency)):
@@ -602,3 +607,33 @@ async def delete_chats(delete_chats_request: DeleteChatsRequest, request: Reques
     except Exception as e:
         logger.error(f"Unexpected error in delete_chats(): {e}")
         raise HTTPException(status_code=500, detail="An unexpected error occurred while deleting chats")
+
+
+@app.post("/advanced_search", tags=["Chat Management"])
+async def advanced_search(
+    search_request: AdvancedSearchRequest,
+    request: Request,
+    auth=Depends(auth_admin_dependency)
+):
+    logger.debug(f"Entering advanced_search() with Correlation ID: {request.state.correlation_id}")
+
+    try:
+        customer_guid = customer_service.get_customer_guid_from_token(request)
+        if not customer_guid:
+            raise HTTPException(status_code=404, detail="Invalid customer_guid provided")
+
+        # Call the advanced search function
+        results = weaviate_manager.search_query_advanced(
+            customer_guid=customer_guid,
+            question=search_request.question,
+            top_k=search_request.top_k,
+            alpha=search_request.alpha
+        )
+        return results
+
+    except HTTPException as e:
+        logger.error(f"HTTPException in advanced_search(): {e.detail}")
+        raise e
+    except Exception as e:
+        logger.error(f"Unexpected error in advanced_search(): {e}")
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during advanced search")


### PR DESCRIPTION
## Summary
- support cross-encoder reranking and page context retrieval
- add `search_query_advanced` API in `WeaviateManager`
- document test command in `AGENTS.md`

## Testing
- `./build/run_backend_testcases.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe67ed85083269411c484753d6b80