### PR TITLE
Fix: Dashboard scrollbar visibility

### DIFF
--- a/src/frontend/src/components/DashboardLayoutContent.tsx
+++ b/src/frontend/src/components/DashboardLayoutContent.tsx
@@ -23,7 +23,7 @@ function DashboardLayoutContentInner({ children, sidebarNavLinks }: DashboardLay
   const { isSidebarOpen } = useDashboardSidebar();
 
   return (
-    <div className="flex h-screen flex-col overflow-auto">
+    <div className="flex h-screen flex-col">
       {/* Global Sidebar */}
       <div className="fixed left-0 top-0 z-50">
         <ChatHistory navLinks={sidebarNavLinks} />


### PR DESCRIPTION
The main dashboard container had `overflow-auto` which caused a scrollbar to always be visible. I removed `overflow-auto` from the main container and kept it on the content container to ensure that only the content area scrolls when necessary. This change ensures the scrollbar is only present when the content exceeds the window size and behaves dynamically on page resize.