### PR TITLE
Implement document-aware chat search

### DIFF
--- a/src/backend/chat_service/llm_service.py
+++ b/src/backend/chat_service/llm_service.py
@@ -338,7 +338,7 @@ class LLMService(metaclass=Singleton):
                         "- If the query is not related to the documents or knowledge base (e.g., small talk), respond appropriately using general knowledge.\n"
                         "- Do not hallucinate.\n"
                         "- Maintain a professional tone and avoid internal commentary.\n\n"
-                        "Search Result Follows:\n"
+                        "Search Result:\n"
                         f"{search_context}"
                     )
                 )


### PR DESCRIPTION
## Summary
- support advanced search of documents via `search_query` instead of removed `search_query_advanced`
- rewrite queries and inject search results in `LLMService`
- fix prompt wording for relevance instructions

## Testing
- `./build/run_backend_testcases.sh -f test_chat.py` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac9802290832693ce8c75a3acdf6e